### PR TITLE
Add support for configurable node groups

### DIFF
--- a/cluster-autoscaler/cloudprovider/juju/juju_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/juju/juju_cloud_provider.go
@@ -190,9 +190,9 @@ func BuildJuju(
 }
 
 func parseNodeGroupName(name string) (string, string, error) {
-	s := strings.Split(name, ",")
+	s := strings.Split(name, ":")
 	if len(s) != 2 {
-		return "", "", fmt.Errorf("failed to parse node group name: %s, expected <model>,<application>", name)
+		return "", "", fmt.Errorf("failed to parse node group name: %s, expected <model>:<application>", name)
 	}
 	model := s[0]
 	application := s[1]

--- a/cluster-autoscaler/cloudprovider/juju/juju_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/juju/juju_cloud_provider.go
@@ -38,13 +38,13 @@ const (
 // jujuCloudProvider implements CloudProvider interface.
 type jujuCloudProvider struct {
 	resourceLimiter *cloudprovider.ResourceLimiter
-	nodeGroup *NodeGroup
+	nodeGroup       *NodeGroup
 }
 
 func newJujuCloudProvider(rl *cloudprovider.ResourceLimiter, nodeGroup *NodeGroup) (*jujuCloudProvider, error) { //TODO
 	return &jujuCloudProvider{
 		resourceLimiter: rl,
-		nodeGroup: nodeGroup,
+		nodeGroup:       nodeGroup,
 	}, nil
 }
 
@@ -139,16 +139,16 @@ func BuildJuju(
 	}
 
 	man := &Manager{
-		units:    make(map[string]*Unit),
+		units: make(map[string]*Unit),
 	}
 	man.init()
 
 	ng := &NodeGroup{
-		id:         "juju",
-		minSize:    3,
-		maxSize:    10,
-		target:     len(man.units),
-		manager:    man,
+		id:      "juju",
+		minSize: 3,
+		maxSize: 10,
+		target:  len(man.units),
+		manager: man,
 	}
 	provider, err := newJujuCloudProvider(rl, ng)
 	if err != nil {

--- a/cluster-autoscaler/cloudprovider/juju/juju_node_group.go
+++ b/cluster-autoscaler/cloudprovider/juju/juju_node_group.go
@@ -31,12 +31,11 @@ import (
 // )
 
 type NodeGroup struct {
-	id         string
-	minSize    int
-	maxSize    int
-	target     int
-	manager    *Manager
-
+	id      string
+	minSize int
+	maxSize int
+	target  int
+	manager *Manager
 }
 
 // MaxSize returns maximum size of the node group.


### PR DESCRIPTION
This PR makes it possible to specify node group information when running cluster-autoscaler:

```
./cluster-autoscaler-amd64 --cloud-provider=juju --nodes 3:10:kubernetes-worker
```

where 3 is the min size, 10 is the max size, and kubernetes-worker is the application name. The `--nodes` option can be specified multiple time to support multiple node groups.

This needs further work. The application name is ignored for now, and there are still some hard-coded assumptions that there is only 1 node group. I'm working on it.