### PR TITLE
Refresh functionality

### DIFF
--- a/cluster-autoscaler/cloudprovider/juju/juju_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/juju/juju_cloud_provider.go
@@ -227,6 +227,7 @@ func BuildJuju(
 			id:      jujuID,
 			minSize: nodeGroupSpec.MinSize,
 			maxSize: nodeGroupSpec.MaxSize,
+			target:  len(man.units),
 			manager: man,
 		}
 		ngs = append(ngs, ng)

--- a/cluster-autoscaler/cloudprovider/juju/juju_node_group.go
+++ b/cluster-autoscaler/cloudprovider/juju/juju_node_group.go
@@ -65,7 +65,7 @@ func (n *NodeGroup) IncreaseSize(delta int) error {
 
 	if targetSize > n.MaxSize() {
 		return fmt.Errorf("size increase is too large. current: %d desired: %d max: %d",
-			targetSize, targetSize, n.MaxSize())
+			n.target, targetSize, n.MaxSize())
 	}
 
 	err := n.manager.addUnits(delta)


### PR DESCRIPTION
Before this PR, the autoscaler essentially ignored any units added or removed external to the autoscaler. It was as if they did not exist. This PR implements the refresh function that is called before each main loop. This adds the ability for the autoscaler to incorporate juju changes external to the autoscaler. i.e., if a juju admin adds or removes a unit manually. The min and max sizes for the scaled application are not strict, min is a lower bound for scaling down. Max is an upper bound for scaling up. 

Unit tests have been updated to test the cases when units are added and removed externally. 